### PR TITLE
Fix for GCC 4.8 and above.

### DIFF
--- a/squangle/mysql_client/Row.h
+++ b/squangle/mysql_client/Row.h
@@ -24,6 +24,7 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <mysql.h>
+#include <chrono>
 
 #include <re2/re2.h>
 


### PR DESCRIPTION
Including chrome is required to support when compiling with GCC 4.8 and above.  This needed to support ARM64 for HHVM.