### PR TITLE
Add getNumOpenConnections to pool

### DIFF
--- a/squangle/mysql_client/AsyncConnectionPool.h
+++ b/squangle/mysql_client/AsyncConnectionPool.h
@@ -507,6 +507,10 @@ class AsyncConnectionPool
 
   PoolKeyStats getPoolKeyStats(const PoolKey& key) const;
 
+  uint32_t getNumOpenConnections() {
+    return num_open_connections_;
+  }
+
   // Don't use the constructor directly, only public to use make_shared
   AsyncConnectionPool(
       std::shared_ptr<AsyncMysqlClient> mysql_client,


### PR DESCRIPTION
Summary:
This change exposes the connection pool number of open connections for
monitoring.

Reviewed By: jupyung

Differential Revision: D30681910

