### PR TITLE
Fix OSS build

### DIFF
--- a/squangle/mysql_client/Connection.cpp
+++ b/squangle/mysql_client/Connection.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "squangle/mysql_client/Connection.h"
+#ifndef SQUANGLE_OSS
 #include "common/db/sql_builder/logging/OdsCounterHelper.h"
+#endif
 #include "squangle/mysql_client/ChangeUserOperation.h"
 #include "squangle/mysql_client/ResetOperation.h"
 #include "squangle/mysql_client/SemiFutureAdapter.h"
@@ -15,6 +17,14 @@
 using namespace std::chrono_literals;
 
 namespace facebook::common::mysql_client {
+
+#ifdef SQUANGLE_OSS
+namespace sql_builder {
+struct OdsCounterHelper {
+  constexpr static void bumpOdsOverallCounter() {}
+};
+} // namespace sql_builder
+#endif
 
 namespace {
 // Helper function to return QueryException when conn is invalid/null

--- a/squangle/mysql_client/Query.cpp
+++ b/squangle/mysql_client/Query.cpp
@@ -222,12 +222,23 @@ std::vector<ArgPair>& QueryArgument::getPairs() {
   return boost::get<std::vector<ArgPair>>(value_);
 }
 
+// Query can be constructed with or without params.
+// By default we deep copy the query text
+Query::Query(const folly::StringPiece query_text)
+    : query_text_(query_text) {}
+
+Query::Query(QueryText&& query_text) : query_text_(std::move(query_text)) {}
+
 Query::Query(
     const folly::StringPiece query_text,
     std::vector<QueryArgument> params)
     : query_text_(query_text),
       unsafe_query_(false),
       params_(std::move(params)) {}
+
+Query::Query(Query&&) = default;
+
+Query::Query(const Query&) = default;
 
 Query::~Query() {}
 

--- a/squangle/mysql_client/Query.h
+++ b/squangle/mysql_client/Query.h
@@ -142,18 +142,15 @@ class Query {
   struct QueryText;
 
  public:
-  // Query can be constructed with or without params.
-  // By default we deep copy the query text
-  explicit Query(const folly::StringPiece query_text)
-      : query_text_(query_text) {}
+  explicit Query(const folly::StringPiece query_text);
 
-  explicit Query(QueryText&& query_text) : query_text_(std::move(query_text)) {}
+  explicit Query(QueryText&& query_text);
 
   ~Query();
 
   // default copy and move constructible
-  Query(const Query&) = default;
-  Query(Query&&) = default;
+  Query(Query&&);
+  Query(const Query& other);
 
   Query& operator=(const Query&) = default;
   Query& operator=(Query&&) = default;

--- a/squangle/mysql_client/mysql_protocol/MysqlConnection.cpp
+++ b/squangle/mysql_client/mysql_protocol/MysqlConnection.cpp
@@ -601,7 +601,7 @@ InternalConnection::Status AsyncMysqlConnection::tryConnect(
       port,
       unixSocket,
       flags,
-      ret);
+      fmt::underlying(ret));
   return toHandlerStatus(ret);
 }
 
@@ -629,7 +629,7 @@ InternalConnection::Status AsyncMysqlConnection::runQuery(
       (void*)mysql_,
       query,
       query.size(),
-      ret);
+      fmt::underlying(ret));
   return toHandlerStatus(ret);
 }
 
@@ -647,7 +647,9 @@ InternalConnection::Status AsyncMysqlConnection::resetConn() const {
 
   auto ret = mysql_reset_connection_nonblocking(mysql_);
   VLOG(4) << fmt::format(
-      "mysql_reset_connection_nonblocking({}) returned {}", (void*)mysql_, ret);
+      "mysql_reset_connection_nonblocking({}) returned {}",
+      (void*)mysql_,
+      fmt::underlying(ret));
   return toHandlerStatus(ret);
 }
 
@@ -691,7 +693,7 @@ InternalConnection::Status AsyncMysqlConnection::changeUser(
       user,
       password,
       database,
-      ret);
+      fmt::underlying(ret));
   return toHandlerStatus(ret);
 }
 
@@ -709,7 +711,7 @@ InternalConnection::Status AsyncMysqlConnection::nextResult() const {
 
   auto ret = mysql_next_result_nonblocking(mysql_);
   VLOG(4) << fmt::format(
-      "mysql_next_result_nonblocking({}) returned {}", (void*)mysql_, ret);
+      "mysql_next_result_nonblocking({}) returned {}", (void*)mysql_, fmt::underlying(ret));
   return toHandlerStatus(ret);
 }
 
@@ -771,7 +773,7 @@ MysqlConnection::MySqlConnectStage MysqlConnection::getMySqlConnectStage()
 
   auto ret = mysql_get_connect_stage(mysql_);
   VLOG(4) << fmt::format(
-      "mysql_get_connect_stage({}) returned {}", (void*)mysql_, ret);
+      "mysql_get_connect_stage({}) returned {}", (void*)mysql_, fmt::underlying(ret));
   return ret;
 }
 

--- a/squangle/mysql_client/mysql_protocol/MysqlResult.cpp
+++ b/squangle/mysql_client/mysql_protocol/MysqlResult.cpp
@@ -83,7 +83,7 @@ InternalResult::FetchRowRet AsyncMysqlResult::fetchRow() {
   VLOG(4) << fmt::format(
       "mysql_fetch_row_nonblocking({}) returned {}, MYSQL_ROW = {}",
       (void*)res_.get(),
-      ret,
+      fmt::underlying(ret),
       (void*)mysqlRow);
 
   if (ret == NET_ASYNC_COMPLETE) {

--- a/squangle/util/StorageRow.h
+++ b/squangle/util/StorageRow.h
@@ -13,7 +13,11 @@
 #include <folly/ScopeGuard.h>
 #include <glog/logging.h>
 
+#ifndef SQUANGLE_OSS
 #include "secure_lib/secure_string.h"
+#else
+#include <cstring>
+#endif
 
 namespace facebook::common::mysql_client {
 
@@ -168,6 +172,15 @@ class StorageRow {
     offsets.curr += sizeof(res);
     return res;
   }
+
+#ifdef SQUANGLE_OSS
+  // Bounds-checked memcpy() shim for Squangle/HHVM OSS.
+  inline static void checked_memcpy(
+      void* dest, std::size_t dest_size, const void* src, std::size_t count) {
+    CHECK(dest_size >= count);
+    std::memcpy(dest, src, count);
+  }
+#endif
 
   double readDouble(Offsets& offsets) const;
   folly::StringPiece readShortString(Offsets& offsets) const;


### PR DESCRIPTION
Squangle as included in HHVM OSS currently doesn't compile. Apply fixes as needed to make the OSS build functional again.

* Use a new SQUANGLE_OSS compile definition for OSS-specific code and to conditionally include Meta-internal headers.
* Introduce OSS-specific shims for OdsCounterHelper and checked_memcpy(), which are internal.
* Use fmt::underlying() to format enums that do not have a corresponding formatter to avoid errors on debug builds with newer fmtlib versions.
* Move Query constructors from the header to the implementation to avoid pointer arithmetic with an incomplete definition of QueryArgument when populating `params_`.