### PR TITLE
Fix -Winconsistent-override in MysqlConnectPoolOperationImpl

### DIFF
--- a/squangle/mysql_client/mysql_protocol/MysqlConnectPoolOperationImpl.h
+++ b/squangle/mysql_client/mysql_protocol/MysqlConnectPoolOperationImpl.h
@@ -130,7 +130,7 @@ class MysqlConnectPoolOperationImpl : public MysqlConnectOperationImpl,
 
   // Called when the connection is matched by the pool client
   void connectionCallback(
-      std::unique_ptr<MysqlPooledHolder<Client>> pooled_conn) {
+      std::unique_ptr<MysqlPooledHolder<Client>> pooled_conn) override {
     // TODO: validate we are in the correct thread (for async)
 
     if (!pooled_conn) {


### PR DESCRIPTION
clang 19 reports -Winconsistent-override for this header:
```
hhvm/third-party/squangle/src/squangle/mysql_client/mysql_protocol/MysqlConnectPoolOperationImpl.h:132:8: warning: 'connectionCallback' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  132 |   void connectionCallback(
      |        ^
hhvm/third-party/squangle/src/squangle/mysql_client/SyncConnectionPool.cpp:62:13: note: in instantiation of template class 'facebook::common::mysql_client::mysql_protocol::MysqlConnectPoolOperationImpl<facebook::common::mysql_client::SyncMysqlClient>' requested here
   62 | std::string SyncConnectPoolOperationImpl::createTimeoutErrorMessage(
      |             ^
hhvm/third-party/squangle/src/squangle/mysql_client/ConnectPoolOperation.h:42:16: note: overridden virtual function is here
   42 |   virtual void connectionCallback(
      |                ^
1 warning generated.
```