### PR TITLE
Add pool-source flag for DB connections

### DIFF
--- a/squangle/mysql_client/Connection.h
+++ b/squangle/mysql_client/Connection.h
@@ -237,6 +237,16 @@ class Connection {
     return mysql_connection_->getLastActivityTime();
   }
 
+  // Pool-source observability
+  [[nodiscard]] bool wasFromPoolHit() const {
+    CHECK_THROW(mysql_connection_ != nullptr, db::InvalidConnectionException);
+    return mysql_connection_->wasFromPoolHit();
+  }
+  [[nodiscard]] bool wasReusedWithChangeUser() const {
+    CHECK_THROW(mysql_connection_ != nullptr, db::InvalidConnectionException);
+    return mysql_connection_->wasReusedWithChangeUser();
+  }
+
   // Returns the MySQL server version. If the connection has been closed
   // an error is generated.
   [[nodiscard]] std::string serverInfo() const {

--- a/squangle/mysql_client/ConnectionHolder.h
+++ b/squangle/mysql_client/ConnectionHolder.h
@@ -93,6 +93,20 @@ class ConnectionHolder : public InternalConnection {
     return lastActiveTime_;
   }
 
+  // Pool-source observability flags
+  void setFromPoolHit(bool v) {
+    fromPoolHit_ = v;
+  }
+  [[nodiscard]] bool wasFromPoolHit() const {
+    return fromPoolHit_;
+  }
+  void setReusedWithChangeUser(bool v) {
+    reusedWithChangeUser_ = v;
+  }
+  [[nodiscard]] bool wasReusedWithChangeUser() const {
+    return reusedWithChangeUser_;
+  }
+
   [[nodiscard]] std::shared_ptr<const ConnectionKey> getKey() const {
     return key_;
   }
@@ -280,6 +294,8 @@ class ConnectionHolder : public InternalConnection {
   bool opened_{false};
   Timepoint createTime_;
   Timepoint lastActiveTime_;
+  bool fromPoolHit_{false};
+  bool reusedWithChangeUser_{false};
 };
 
 } // namespace facebook::common::mysql_client

--- a/squangle/mysql_client/ConnectionPool.h
+++ b/squangle/mysql_client/ConnectionPool.h
@@ -532,6 +532,8 @@ class ConnectionPool
       // Cache hit
       stats()->incrPoolHits();
 
+      // mark handout as coming from pool cache
+      mysql_conn->setFromPoolHit(true);
       mysql_conn->setReusable(true);
       raw_pool_op->connectionCallback(std::move(mysql_conn));
     }
@@ -631,6 +633,8 @@ class ConnectionPool
           stats()->incrPoolHits();
           stats()->incrPoolHitsChangeUser();
 
+          pooledConn->setFromPoolHit(true);
+          pooledConn->setReusedWithChangeUser(true);
           pooledConn->setReusable(true);
           rawPoolOp->connectionCallback(std::move(pooledConn));
         });
@@ -820,6 +824,8 @@ class ConnectionPool
       VLOG(11) << "No operations waiting for Connection, enqueueing it";
       conn_storage_.queueConnection(std::move(mysql_conn));
     } else {
+      // Flag as hit when recycled (brand_new == false); miss when just created.
+      mysql_conn->setFromPoolHit(!brand_new);
       mysql_conn->setReusable(true);
       pool_op->connectionCallback(std::move(mysql_conn));
     }


### PR DESCRIPTION
It would be useful for userland Hack code in Slack to determine whether a connection obtained via an HHVM async_mysql connection pool was recycled from the pool or freshly opened, to allow more granular instrumentation than what pool-level stats currently provide. See https://github.com/facebook/hhvm/issues/8013 for the full rationale.

Add two new connection fields that expose this information. A followup diff will expose these to HHVM/Hack.