### PR TITLE
Remove operation from wait list in dequeueOperation

### DIFF
--- a/squangle/mysql_client/PoolStorage.h
+++ b/squangle/mysql_client/PoolStorage.h
@@ -84,7 +84,12 @@ class PoolStorageData {
       return locked_op && locked_op.get() == &pool_op;
     });
 
-    return it != list.end();
+    if (it == list.end()) {
+      return false;
+    }
+
+    list.erase(it);
+    return true;
   }
 
   // Calls failureCallback with the error description and removed all


### PR DESCRIPTION
## What

`PoolStorageData::dequeueOperation()` now actually erases the operation from the wait list when it is found, matching its documented behavior ("Searches for an operation in the queue and removes it"). Previously it only returned whether the operation was present.

## Why

Two call sites depend on the removal side effect:

- `SyncConnectionPool::openNewConnectionFinish()` (SyncConnectionPool.cpp) — on sync-wait timeout the operation must be dequeued before `timeoutTriggered()` runs. With the bug the timed-out operation stayed queued, and the `!dequeueOperation(...)` branch that waits for another thread to fulfill the operation could effectively never trigger.
- `ConnectionPool::openNewConnection()` (ConnectionPool.h) — the throttling callback dequeues an operation that has just been marked failed; its comment states no other thread could have dequeued it yet, which only makes sense if dequeue actually removes.

Without the erase, done/timed-out operations remain in `waitList_` until `cleanupOperations()` or a subsequent `popOperation()` discards them. In the meantime `numQueuedOperations()` is inflated, feeding `canCreateMoreConnections()` and potentially delaying new connections.

## Testing

- Change is self-contained in `PoolStorageData::dequeueOperation`. Erase is safe: it runs while holding the pool-data lock (or on the single client thread for the sync pool), and the operation is already marked failed/done at both call sites, so no other path can hold a reference that requires it to stay queued.
- Minimal behavioral change; no new dependencies.